### PR TITLE
🔥 delete old code

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,5 +1,0 @@
-doctrine_migrations:
-    dir_name: '%kernel.project_dir%/src/Migrations'
-    # namespace is arbitrary but should be different from App\Migrations
-    # as migrations classes should NOT be autoloaded
-    namespace: DoctrineMigrations


### PR DESCRIPTION
The last version of Doctrine don't need it
Cause the error : 

Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In ArrayNode.php line 320:
!!                                                                                 
!!    Unrecognized options "dir_name, namespace" under "doctrine_migrations". Ava  
!!    ilable options are "all_or_nothing", "check_database_platform", "connection  
!!    ", "custom_template", "em", "enable_profiler", "factories", "migrations", "  
!!    migrations_paths", "organize_migrations", "services", "storage".             
!!                                                                                 
!!  
!!  
Script @auto-scripts was called via post-update-cmd